### PR TITLE
Fix "Java CD" workflow responsible for automated publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,8 @@ jobs:
           name: ${{ steps.mod_version.outputs.value }} (${{ steps.supported_minecraft_version.outputs.value }})
           github-tag: v${{ steps.mod_version.outputs.value }}+mc${{ steps.supported_minecraft_version.outputs.value }}
           files: |
-            build/libs/!(*-@(dev|sources|javadoc)).jar
-            build/libs/*-@(dev|sources|javadoc).jar
+            build/libs/!(*-@(sources|dev-shadow|javadoc)).jar
+            **/build/libs/*-@(sources|dev-shadow|javadoc).jar
           version-type: release
           modrinth-featured: false
           changelog-file: CHANGELOG_LATEST.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
           name: ${{ steps.mod_version.outputs.value }} (${{ steps.supported_minecraft_version.outputs.value }})
           github-tag: v${{ steps.mod_version.outputs.value }}+mc${{ steps.supported_minecraft_version.outputs.value }}
           files: |
-            **/build/libs/!(*-@(sources|dev|dev-shadow|javadoc).jar)
+            **/build/libs/!(*-@(sources|dev|dev-shadow|javadoc)).jar
             **/build/libs/*-@(sources|dev|dev-shadow|javadoc).jar
           version-type: release
           modrinth-featured: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,8 @@ jobs:
           name: ${{ steps.mod_version.outputs.value }} (${{ steps.supported_minecraft_version.outputs.value }})
           github-tag: v${{ steps.mod_version.outputs.value }}+mc${{ steps.supported_minecraft_version.outputs.value }}
           files: |
-            **/build/libs/!(*-@(sources|dev|dev-shadow|javadoc)).jar
-            **/build/libs/*-@(sources|dev|dev-shadow|javadoc).jar
+            build/libs/!(*-@(dev|sources|javadoc)).jar
+            build/libs/*-@(dev|sources|javadoc).jar
           version-type: release
           modrinth-featured: false
           changelog-file: CHANGELOG_LATEST.md

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -54,6 +54,7 @@ processResources {
                 "mod_name": rootProject.mod_name,
                 "mod_description": rootProject.mod_description,
                 "mod_license": rootProject.mod_license,
+                "curseforge_project_id": rootProject.curseforge_project_id,
                 "modrinth_project_id": rootProject.modrinth_project_id,
                 "fabric_loader_version": rootProject.fabric_loader_version,
                 "supported_minecraft_version": rootProject.supported_minecraft_version

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
         "forge",
         "neoforge"
       ],
-      "curseforge": 930207,
+      "curseforge": "${curseforge_project_id}",
       "modrinth": "${modrinth_project_id}"
     }
   },

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -55,6 +55,7 @@ processResources {
                 "mod_name": rootProject.mod_name,
                 "mod_description": rootProject.mod_description,
                 "mod_license": rootProject.mod_license,
+                "curseforge_project_id": rootProject.curseforge_project_id,
                 "modrinth_project_id": rootProject.modrinth_project_id,
                 "neoforge_version": rootProject.neoforge_version,
                 "supported_minecraft_version": rootProject.supported_minecraft_version

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ displayURL = "https://github.com/Steveplays28/${mod_id}"
 
 [mc-publish]
 loaders = ["fabric", "quilt", "forge", "neoforge"]
-curseforge = 930207
+curseforge = "${curseforge_project_id}"
 modrinth = "${modrinth_project_id}"
 
 [[dependencies.noisium]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ minecraft_version=1.20.1
 enabled_platforms=fabric,forge
 
 # mc-publish properties
+curseforge_project_id=930207
 modrinth_project_id=KuNKN7d2
 
 # Fabric properties


### PR DESCRIPTION
This PR fixes *(or at least it should fix)* your publishing workflow.

A dry run of `mc-publish` results in the following output:

```
CurseForge ID: 930207
Modrinth ID: KuNKN7d2
Primary file type: fabric, quilt, forge, neoforge
Publishing: build/libs/noisium-merged-2.0.0+mc1.20.x.jar
Publishing: common/build/libs/noisium-common-2.0.0+mc1.20.x-sources.jar
Publishing: fabric/build/libs/noisium-fabric-2.0.0+mc1.20.x-dev-shadow.jar
Publishing: fabric/build/libs/noisium-fabric-2.0.0+mc1.20.x-sources.jar
Publishing: forge/build/libs/noisium-forge-2.0.0+mc1.20.x-dev-shadow.jar
Publishing: forge/build/libs/noisium-forge-2.0.0+mc1.20.x-sources.jar
```

As you can see, your mod's metadata is read correctly, and all the necessary jars are selected for publication in the expected order *(i.e., `noisium-merged-2.0.0+mc1.20.x.jar` is the primary file, and the others are secondary)*.

Once again, note that `mc-publish` only reads one metadata file per jar. This decision was made under the assumption, which was reasonable at the time, that nobody would merge mods for different mod loaders into a single binary. Thus, given that my beloved Fabric has a *completely unbiased* higher priority internally, only `fabric.mod.json` is read. So, feel free to clean up `mods.toml` from duplicate entries if you feel like it :)

---

See Kir-Antipov/mc-publish#114.

