### PR TITLE
Added support for 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,15 +13,15 @@ mod_name=Noisium
 mod_description=Optimises worldgen performance for a better gameplay experience.
 mod_license=LGPL-3.0
 mod_version=2.7.0
-supported_minecraft_version=1.21.6
-supported_minecraft_version_name=1.21.6
+supported_minecraft_version=1.21.8
+supported_minecraft_version_name=1.21.8
 
 # Multiloader properties
 architectury_plugin_version=3.4-SNAPSHOT
 architectury_loom_version=1.10-SNAPSHOT
 shadow_plugin_version=7.1.2
-forgix_plugin_version=1.2.6
-minecraft_version=1.21.6
+forgix_plugin_version=1.2.8
+minecraft_version=1.21.8
 java_version=21
 enabled_platforms=fabric,neoforge
 
@@ -31,13 +31,13 @@ modrinth_project_id=KuNKN7d2
 
 # Fabric properties
 # Check these on https://modmuss50.me/fabric.html
-yarn_mappings=1.21.6+build.1
+yarn_mappings=1.21.8+build.1
 fabric_loader_version=0.16.14
 
 # NeoForge properties
-neoforge_version=21.6.15-beta
+neoforge_version=21.8.2-beta
 
 # Dependencies
 mixin_extras_version=0.3.5
-fabric_api_version=0.128.0+1.21.6
+fabric_api_version=0.129.0+1.21.8
 mod_menu_version=15.0.0-beta.3


### PR DESCRIPTION
### Adds support for Minecraft `1.21.8` and updates all related dependencies.

### Version Updates

- `supported_minecraft_version`: `1.21.8`
- `supported_minecraft_version_name`: `1.21.8`
- `minecraft_version`: `1.21.8`

### Dependency Updates

- `forgix_plugin_version`: `1.2.8`
- `yarn_mappings`: `1.21.8+build.1`
- `fabric_api_version`: `0.129.0+1.21.8`
- `neoforge_version`: `21.8.2-beta`
